### PR TITLE
Add Xquik API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ a list of websites using [documentation](https://github.com/documentationjs/docu
 * [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/api/)
 * [Turf](http://turfjs.org/docs/)
 * [Simple Statistics](http://simplestatistics.org/docs/)
+* [Xquik API Documentation](https://docs.xquik.com) - REST API documentation for the Xquik X/Twitter automation platform. Covers 40+ API endpoints, MCP server setup, webhook integration, OpenAPI spec, and interactive examples. ([source](https://github.com/Xquik-dev/xquik-docs))
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add Xquik API Documentation to the list
- Xquik provides REST API docs for an X/Twitter automation platform covering 40+ endpoints, MCP server setup, webhook integration, OpenAPI spec, and interactive examples
- Docs site: https://docs.xquik.com | Source: https://github.com/Xquik-dev/xquik-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)